### PR TITLE
Usefully complain when tocparser.py can't parse an entry

### DIFF
--- a/pdftocio/app.py
+++ b/pdftocio/app.py
@@ -132,6 +132,11 @@ def main():
         print("error: unable to open file", file=sys.stderr)
         print(e, file=sys.stderr)
         sys.exit(1)
+    except IndexError as e:
+        if args.debug:
+            raise e
+        print("index error:", e, file=sys.stderr)
+        sys.exit(1)
     except KeyboardInterrupt as e:
         if args.debug:
             raise e

--- a/pdftocio/tocparser.py
+++ b/pdftocio/tocparser.py
@@ -1,6 +1,7 @@
 """Parser for table of content csv file"""
 
 import csv
+import sys
 
 from typing import IO, List
 from fitzutils import ToCEntry
@@ -14,7 +15,6 @@ def parse_entry(entry: List) -> ToCEntry:
     # only need to count the number of '' before an entry to determined the
     # heading level
     indent = len(list(takewhile(lambda x: x == '', entry)))
-    
     try:
         toc_entry = ToCEntry(
             int(indent / 4) + 1,     # 4 spaces = 1 level
@@ -22,11 +22,11 @@ def parse_entry(entry: List) -> ToCEntry:
             int(entry[indent + 1]),  # pagenum
             *entry[indent + 2:]      # vpos
         )
-        
         return toc_entry
-    
     except IndexError as e:
-        print ("Unable to parse toc entry %s; Need at least %s parts but only have %s -> %s" % (entry, indent + 2, len(entry), e))
+        print(f"Unable to parse toc entry {entry}; "
+              f"Need at least {indent + 2} parts but only have {len(entry)}.",
+              file=sys.stderr)
         raise e
 
 

--- a/pdftocio/tocparser.py
+++ b/pdftocio/tocparser.py
@@ -14,12 +14,20 @@ def parse_entry(entry: List) -> ToCEntry:
     # only need to count the number of '' before an entry to determined the
     # heading level
     indent = len(list(takewhile(lambda x: x == '', entry)))
-    return ToCEntry(
-        int(indent / 4) + 1,     # 4 spaces = 1 level
-        entry[indent],           # heading
-        int(entry[indent + 1]),  # pagenum
-        *entry[indent + 2:]      # vpos
-    )
+    
+    try:
+        toc_entry = ToCEntry(
+            int(indent / 4) + 1,     # 4 spaces = 1 level
+            entry[indent],           # heading
+            int(entry[indent + 1]),  # pagenum
+            *entry[indent + 2:]      # vpos
+        )
+        
+        return toc_entry
+    
+    except IndexError as e:
+        print ("Unable to parse toc entry %s; Need at least %s parts but only have %s -> %s" % (entry, indent + 2 + 1, len(entry), e))
+        raise e
 
 
 def parse_toc(file: IO) -> List[ToCEntry]:

--- a/pdftocio/tocparser.py
+++ b/pdftocio/tocparser.py
@@ -25,7 +25,8 @@ def parse_entry(entry: List) -> ToCEntry:
         return toc_entry
     except IndexError as e:
         print(f"Unable to parse toc entry {entry}; "
-              f"Need at least {indent + 2} parts but only have {len(entry)}.",
+              f"Need at least {indent + 2} parts but only have {len(entry)}. ",
+              "Make sure the page number is present.",
               file=sys.stderr)
         raise e
 

--- a/pdftocio/tocparser.py
+++ b/pdftocio/tocparser.py
@@ -26,7 +26,7 @@ def parse_entry(entry: List) -> ToCEntry:
         return toc_entry
     
     except IndexError as e:
-        print ("Unable to parse toc entry %s; Need at least %s parts but only have %s -> %s" % (entry, indent + 2 + 1, len(entry), e))
+        print ("Unable to parse toc entry %s; Need at least %s parts but only have %s -> %s" % (entry, indent + 2, len(entry), e))
         raise e
 
 

--- a/spec/parser_spec.py
+++ b/spec/parser_spec.py
@@ -53,3 +53,13 @@ with description("parse_toc") as self:
         ]
         f = io.StringIO(quoted)
         assert parse_toc(f) == expect
+
+    with it("raises error when toc entry is invalid"):
+        malformed = '"entry" 1\n    "error entry"'
+        f = io.StringIO(malformed)
+        try:
+            parse_toc(f)
+        except IndexError:
+            pass
+        else:
+            assert False, "must raise error"


### PR DESCRIPTION
Hello there,

Thanks for making this program! I'm currently using it to fix a PDF I have here.

In this pull request, I've added some code to give a more useful complaint when tocparser.py encounters a malformed table of contents file. I was struggling with my own toc file, and this helped me find where I had gone wrong.