### PR TITLE
support non-ASCII TOC

### DIFF
--- a/pdftocio/app.py
+++ b/pdftocio/app.py
@@ -104,7 +104,7 @@ def main():
             print_toc = True
         elif o in ("-t", "--toc"):
             try:
-                toc_file = open(a, "r")
+                toc_file = open(a, "r", encoding="utf-8")
             except IOError as e:
                 print("error: can't open file for reading", file=sys.stderr)
                 print(e, file=sys.stderr)


### PR DESCRIPTION
I import a Chinese TOC to a pdf, the final TOC in pdf are full of unrecognized characters. This PR fixes the bug.
