### PR TITLE
fix the encoding error on Windows

### DIFF
--- a/fitzutils/__init__.py
+++ b/fitzutils/__init__.py
@@ -4,7 +4,8 @@ from .fitzutils import (
     open_pdf,
     ToCEntry,
     dump_toc,
-    pprint_toc
+    pprint_toc,
+    check_charset
 )
 
 __all__ = [
@@ -12,4 +13,5 @@ __all__ = [
     'ToCEntry',
     'dump_toc',
     'pprint_toc',
+    'check_charset',
 ]

--- a/fitzutils/fitzutils.py
+++ b/fitzutils/fitzutils.py
@@ -7,7 +7,13 @@ import sys
 import fitz
 import io
 import csv
+import chardet
 
+def check_charset(file_path):
+    with open(file_path, "rb") as f:
+        data = f.read(4)
+        charset = chardet.detect(data)['encoding']
+    return charset
 
 @contextmanager
 def open_pdf(path: str,

--- a/pdftocgen/app.py
+++ b/pdftocgen/app.py
@@ -7,7 +7,7 @@ import pdftocgen
 
 from getopt import GetoptError
 from typing import TextIO
-from fitzutils import open_pdf, dump_toc, pprint_toc
+from fitzutils import open_pdf, dump_toc, pprint_toc, check_charset
 from .tocgen import gen_toc
 
 usage_s = """
@@ -102,7 +102,7 @@ def main():
             vpos = True
         elif o in ("-r", "--recipe"):
             try:
-                recipe_file = open(a, "r")
+                recipe_file = open(a, "r", encoding=check_charset(a))
             except IOError as e:
                 print("error: can't open file for reading", file=sys.stderr)
                 print(e, file=sys.stderr)

--- a/pdftocio/app.py
+++ b/pdftocio/app.py
@@ -7,7 +7,7 @@ import getopt
 
 from typing import Optional, TextIO
 from getopt import GetoptError
-from fitzutils import open_pdf, dump_toc, pprint_toc
+from fitzutils import open_pdf, dump_toc, pprint_toc, check_charset
 from .tocparser import parse_toc
 from .tocio import write_toc, read_toc
 
@@ -104,7 +104,7 @@ def main():
             print_toc = True
         elif o in ("-t", "--toc"):
             try:
-                toc_file = open(a, "r")
+                toc_file = open(a, "r", encoding=check_charset(a))
             except IOError as e:
                 print("error: can't open file for reading", file=sys.stderr)
                 print(e, file=sys.stderr)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ packages = [
 python = "^3.7"
 PyMuPDF = "^1.18.14"
 toml = "^0.10.2"
+charset = "^1.0.1"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.5.3"


### PR DESCRIPTION
The original code on Windows with Python 3.7.9 produces the following error when dealing with a Chinese PDF file.

```
> pdfxmeta -p 17 -a 1 TaoYuan.pdf "第一章" > toc.toml
  File "c:\users\j.shi\scoop\apps\python37\3.7.9\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\users\j.shi\scoop\apps\python37\3.7.9\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\J.Shi\scoop\apps\python37\current\scripts\pdftocgen.exe\__main__.py", line 7, in <module>
  File "c:\users\j.shi\scoop\apps\python37\3.7.9\lib\site-packages\pdftocgen\app.py", line 144, in main
    raise e
  File "c:\users\j.shi\scoop\apps\python37\3.7.9\lib\site-packages\pdftocgen\app.py", line 136, in main
    recipe = toml.load(recipe_file)
  File "c:\users\j.shi\scoop\apps\python37\3.7.9\lib\site-packages\toml\decoder.py", line 156, in load
    return loads(f.read(), _dict, decoder)
UnicodeDecodeError: 'gbk' codec can't decode byte 0xff in position 0: illegal multibyte sequence
```

The error is due to the encoding setting when open a file.

I add a piece of codes to detect the file encoding and open the file with the detected encoding.
It works now on Windows with the following commands without `set PYTHONUTF8=1`.

```
pdfxmeta -p 17 -a 1 TaoYuan.pdf "第一章" > recipe.toml
pdftocgen -r recipe.toml TaoYuan.pdf > toc.txt
pdftocio -t toc.txt -o TaoYuan_WithToc.pdf TaoYuan.pdf
```

The generated PDF file has the outline as follows,

![image](https://user-images.githubusercontent.com/9106886/143665873-9078aee0-9ac5-4052-b2a9-f0b2fa347734.png)

