### PR TITLE
Fix for issue #22: prevent KeyError

### DIFF
--- a/pdftocio/tocio.py
+++ b/pdftocio/tocio.py
@@ -14,7 +14,7 @@ def write_toc(doc: Document, toc: List[ToCEntry]):
 def read_toc(doc: Document) -> List[ToCEntry]:
     """Read table of contents from a document"""
     return [
-        ToCEntry(e[0], e[1], e[2], e[3]['to'].y) if len(e) == 4 else
+        ToCEntry(e[0], e[1], e[2], e[3]['to'].y) if (len(e) == 4 and 'to' in e[3]) else
         ToCEntry(e[0], e[1], e[2])
         for e in doc.get_toc(False)
     ]


### PR DESCRIPTION
This fixes the KeyError produced when a bookmark has a fit other than the expected "fit top-left and zoom" by checking for the presence of the dictionary item.