### PR TITLE
add feature: include line number in toc parse error message

### DIFF
--- a/pdftocgen/app.py
+++ b/pdftocgen/app.py
@@ -90,7 +90,7 @@ def main():
         print(usage_s, file=sys.stderr)
         sys.exit(2)
 
-    recipe_file: TextIO = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8', errors='ignore')
+    recipe_file: TextIO = None
     readable: bool = False
     vpos: bool = False
     out: TextIO = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', errors='ignore')
@@ -129,6 +129,8 @@ def main():
         print(usage_s, file=sys.stderr)
         sys.exit(1)
 
+    if not recipe_file:
+        recipe_file = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8', errors='ignore')
     path_in: str = args[0]
     # done parsing arguments
 

--- a/pdftocio/app.py
+++ b/pdftocio/app.py
@@ -94,7 +94,7 @@ def main():
         print(usage_s, file=sys.stderr)
         sys.exit(2)
 
-    toc_file: TextIO = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8', errors='ignore')
+    toc_file: TextIO = None
     print_toc: bool = False
     readable: bool = False
     out: Optional[str] = None
@@ -131,6 +131,8 @@ def main():
         print(usage_s, file=sys.stderr)
         sys.exit(1)
 
+    if not toc_file:
+        toc_file = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8', errors='ignore')
     path_in: str = args[0]
     # done parsing arguments
 

--- a/pdftocio/tocparser.py
+++ b/pdftocio/tocparser.py
@@ -5,10 +5,10 @@ import sys
 
 from typing import IO, List
 from fitzutils import ToCEntry
-from itertools import takewhile
+from itertools import count, takewhile
 
 
-def parse_entry(entry: List) -> ToCEntry:
+def parse_entry(entry: List, nLine: int) -> ToCEntry:
     """parse a row in csv to a toc entry"""
 
     # a somewhat weird hack, csv reader would read spaces as an empty '', so we
@@ -24,7 +24,7 @@ def parse_entry(entry: List) -> ToCEntry:
         )
         return toc_entry
     except IndexError as e:
-        print(f"Unable to parse toc entry {entry};",
+        print(f"Unable to parse toc entry {entry} from line {nLine};",
               f"Need at least {indent + 2} parts but only have {len(entry)}.",
               "Make sure the page number is present.",
               file=sys.stderr)
@@ -35,4 +35,4 @@ def parse_toc(file: IO) -> List[ToCEntry]:
     """Parse a toc file to a list of toc entries"""
     reader = csv.reader(file, lineterminator='\n',
                         delimiter=' ', quoting=csv.QUOTE_NONNUMERIC)
-    return list(map(parse_entry, reader))
+    return list(map(parse_entry, reader, count(1)))

--- a/pdftocio/tocparser.py
+++ b/pdftocio/tocparser.py
@@ -23,6 +23,11 @@ def parse_entry(entry: List, nLine: int) -> ToCEntry:
             *entry[indent + 2:]      # vpos
         )
         return toc_entry
+    except ValueError as e:
+        print(f"Unable to parse toc entry {entry} from line {nLine};",
+              f"Couldn't convert '{entry[indent + 1]}' to a page number.",
+              file=sys.stderr)
+        raise e
     except IndexError as e:
         print(f"Unable to parse toc entry {entry} from line {nLine};",
               f"Need at least {indent + 2} parts but only have {len(entry)}.",


### PR DESCRIPTION
Currently, when there's an error parsing a toc entry, it's difficult to find which entry caused the error, as there isn't much context provided in the error message. This commit adds line number information to the error message so users can know which line generated the parse error.